### PR TITLE
Update the return value of FUSE.listxattr

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -577,7 +577,9 @@ class FUSE(object):
 
     def listxattr(self, path, namebuf, size):
         attrs = self.operations('listxattr', path.decode(self.encoding)) or ''
-        ret = '\x00'.join(attrs).encode(self.encoding) + '\x00'
+        ret = '\x00'.join(attrs).encode(self.encoding)
+        if len(ret) > 0:
+            ret += '\x00'
 
         retsize = len(ret)
         # allow size queries


### PR DESCRIPTION
By adding the extra '\x00' character to an otherwise empty string, fusepy makes it look like a file with no extra attributes has one (nameless?) attribute.

```xattr FILE``` prints a blank line, 

```xattr -l FILE``` prints "xattr: [Errno 22] Invalid argument: 'FILE'"