### PR TITLE
unused create_string_buffer return value

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -506,7 +506,7 @@ class FUSE(object):
             'actual amount read %d greater than expected %d' % (retsize, size)
 
         data = create_string_buffer(ret, retsize)
-        memmove(buf, ret, retsize)
+        memmove(buf, data, retsize)
         return retsize
 
     def write(self, path, buf, size, offset, fip):


### PR DESCRIPTION
the create_string_buffer call makes it look like you wanted to do this -- however it seems to work either way.