### PR TITLE
Add support for arm64 architecture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ To get started download_ fusepy or just browse the source_.
 
 fusepy requires FUSE 2.6 (or later) and runs on:
 
-- Linux (i386, x86_64, PPC)
+- Linux (i386, x86_64, PPC, arm64)
 - Mac OS X (Intel, PowerPC)
 - FreeBSD (i386, amd64)
 

--- a/fuse.py
+++ b/fuse.py
@@ -171,6 +171,23 @@ elif _system == 'Linux':
             ('st_atimespec', c_timespec),
             ('st_mtimespec', c_timespec),
             ('st_ctimespec', c_timespec)]
+    elif _machine == 'aarch64':
+        c_stat._fields_ = [
+            ('st_dev', c_dev_t),
+            ('st_ino', c_ulong),
+            ('st_mode', c_mode_t),
+            ('st_nlink', c_uint),
+            ('st_uid', c_uid_t),
+            ('st_gid', c_gid_t),
+            ('st_rdev', c_dev_t),
+            ('__pad1', c_ulong),
+            ('st_size', c_off_t),
+            ('st_blksize', c_int),
+            ('__pad2', c_int),
+            ('st_blocks', c_long),
+            ('st_atimespec', c_timespec),
+            ('st_mtimespec', c_timespec),
+            ('st_ctimespec', c_timespec)]
     else:
         # i686, use as fallback for everything else
         c_stat._fields_ = [


### PR DESCRIPTION
The following change enables fuse.py to work on "aarch64" running Linux. I tested this on a Juno ARMv8 development platform system running Debian Jessie (with a 4.3 kernel and some additional ARM patches) and used the memory.py example script.

Without this change the memory.py script fails with the following error:
*** stack smashing detected ***: python terminated
Aborted