### PR TITLE
Fix octal integer literals in examples

### DIFF
--- a/examples/context.py
+++ b/examples/context.py
@@ -14,16 +14,16 @@ class Context(LoggingMixIn, Operations):
     def getattr(self, path, fh=None):
         uid, gid, pid = fuse_get_context()
         if path == '/':
-            st = dict(st_mode=(S_IFDIR | 0755), st_nlink=2)
+            st = dict(st_mode=(S_IFDIR | 0o755), st_nlink=2)
         elif path == '/uid':
             size = len('%s\n' % uid)
-            st = dict(st_mode=(S_IFREG | 0444), st_size=size)
+            st = dict(st_mode=(S_IFREG | 0o444), st_size=size)
         elif path == '/gid':
             size = len('%s\n' % gid)
-            st = dict(st_mode=(S_IFREG | 0444), st_size=size)
+            st = dict(st_mode=(S_IFREG | 0o444), st_size=size)
         elif path == '/pid':
             size = len('%s\n' % pid)
-            st = dict(st_mode=(S_IFREG | 0444), st_size=size)
+            st = dict(st_mode=(S_IFREG | 0o444), st_size=size)
         else:
             raise FuseOSError(ENOENT)
         st['st_ctime'] = st['st_mtime'] = st['st_atime'] = time()

--- a/examples/memory.py
+++ b/examples/memory.py
@@ -21,11 +21,11 @@ class Memory(LoggingMixIn, Operations):
         self.data = defaultdict(bytes)
         self.fd = 0
         now = time()
-        self.files['/'] = dict(st_mode=(S_IFDIR | 0755), st_ctime=now,
+        self.files['/'] = dict(st_mode=(S_IFDIR | 0o755), st_ctime=now,
                                st_mtime=now, st_atime=now, st_nlink=2)
 
     def chmod(self, path, mode):
-        self.files[path]['st_mode'] &= 0770000
+        self.files[path]['st_mode'] &= 0o770000
         self.files[path]['st_mode'] |= mode
         return 0
 
@@ -103,7 +103,7 @@ class Memory(LoggingMixIn, Operations):
         return dict(f_bsize=512, f_blocks=4096, f_bavail=2048)
 
     def symlink(self, target, source):
-        self.files[target] = dict(st_mode=(S_IFLNK | 0777), st_nlink=1,
+        self.files[target] = dict(st_mode=(S_IFLNK | 0o777), st_nlink=1,
                                   st_size=len(source))
 
         self.data[target] = source

--- a/examples/memoryll.py
+++ b/examples/memoryll.py
@@ -21,7 +21,7 @@ class Memory(FUSELL):
         self.parent = {}
         self.children = defaultdict(dict)
         
-        self.attr[1] = {'st_ino': 1, 'st_mode': S_IFDIR | 0777, 'st_nlink': 2}
+        self.attr[1] = {'st_ino': 1, 'st_mode': S_IFDIR | 0o777, 'st_nlink': 2}
         self.parent[1] = 1
     
     forget = None


### PR DESCRIPTION
The form of octal literals used is compatible with Python 2.6+ and
Python 3.