### PR TITLE
One enhancement, One bugfix

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -383,7 +383,9 @@ def time_of_timespec(ts):
 def set_st_attrs(st, attrs):
     for key, val in attrs.items():
         if key in ('st_atime', 'st_mtime', 'st_ctime', 'st_birthtime'):
-            timespec = getattr(st, key + 'spec')
+            timespec = getattr(st, key + 'spec', None)
+            if timespec is None:
+                continue
             timespec.tv_sec = int(val)
             timespec.tv_nsec = int((val - timespec.tv_sec) * 10 ** 9)
         elif hasattr(st, key):


### PR DESCRIPTION
Add support for flags in pyfuse.Operations: This lets user's specify important flags like `flag_nopath` to the fuse library. Also some adjustments to the dispatch code was made to allow for empty paths.

Ignore input time field if it doesn't exist on stat: If a user's getattr() returns a stat dict with "st_birthtime" but the underlying system doesn't support it, it used to throw an exception. this fixes that.