### PR TITLE
Add fusell to setuptools exports.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     maintainer = 'Terence Honles',
     maintainer_email = 'terence@honles.com',
     license = 'ISC',
-    py_modules=['fuse'],
+    py_modules=['fuse', 'fusell'],
     url = 'http://github.com/terencehonles/fusepy',
 
     classifiers = [


### PR DESCRIPTION
fusepy dosen't seem to include fusell. I'd like to include it, so I can depend on fusepy via pypi or common distro packaging and use fusell.